### PR TITLE
fix(nom-de-plume): improve ndp deployment

### DIFF
--- a/nom-de-plume/deployment.yaml
+++ b/nom-de-plume/deployment.yaml
@@ -18,6 +18,10 @@ spec:
             - secretRef:
                 name: nom-de-plume
           resources:
-            limits:
+            requests:
               memory: "128Mi"
-              cpu: "500m"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "1"
+  revisionHistoryLimit: 0


### PR DESCRIPTION
Increase the resource limits for nom-de-plume to stop pods getting
stopped for memory. Also remove the the revision history to clean up old
replica sets.