### PR TITLE
chore: remove scheduling for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>SVendittelli/renovate-config"],
+  "extends": ["github>SVendittelli/renovate-config:base"],
   "kubernetes": {
     "fileMatch": ["\\.yaml$"]
   }


### PR DESCRIPTION
So that we get the newest changes sooner, remove the default scheduling configuration from renovate.